### PR TITLE
通过局部变量缓存length，避免每次迭代过程中都产生属性访问的开销。

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,6 +13,8 @@ function deserialize(value) {
 }
 function isFunction(value) { return ({}).toString.call(value) === "[object Function]"; }
 function isArray(value) { return Object.prototype.toString.call(value) === "[object Array]"; }
+// https://github.com/jaywcjlove/store.js/pull/8
+// Error: QuotaExceededError
 function dealIncognito(storage) {
   var _KEY = '_Is_Incognit', _VALUE = 'yes';
   try { storage.setItem(_KEY, _VALUE) }
@@ -73,7 +75,7 @@ Store.prototype = {
     return d;
   },
   forEach: function (callback) {
-    for (var i = 0; i < storage.length; i++) {
+    for (var i = 0, len = storage.length; i < len; i++) {
       var key = storage.key(i);
       if (callback(key, this.get(key)) === false) break;
     }
@@ -81,7 +83,7 @@ Store.prototype = {
   },
   search: function (str) {
     var arr = this.keys(), dt = {};
-    for (var i = 0; i < arr.length; i++) {
+    for (var i = 0, len = arr.length; i < len; i++) {
       if (arr[i].indexOf(str) > -1) dt[arr[i]] = this.get(arr[i]);
     }
     return dt;
@@ -108,7 +110,7 @@ function store(key, data) {
     }
   }
   if (argm.length === 2 && isArray(key) && isFunction(data)) {
-    for (var i = 0; i < key.length; i++) {
+    for (var i = 0, len = key.length; i < len; i++) {
       dt = data(key[i], _Store.get(key[i]))
       store.set(key[i], dt)
     }


### PR DESCRIPTION
属性的访问涉及[scope]中的查找，每一次访问属性都是有开销的，在循环体中使用```arr.length```的时候就会不停的进行属性访问，应该使用局部变量缓存起来。