### PR TITLE
fix ignored falsy values when getting with multiple keys

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -65,7 +65,7 @@ Store.prototype = {
       const dt = {};
       for (var i = 0, len = args.length; i < len; i++) {
         const value = deserialize(storage.getItem(args[i]));
-        if (value) {
+        if (this.has(args[i])) {
           dt[args[i]] = value;
         }
       }

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -78,13 +78,31 @@ test('Test localstorage forEach', () => {
 });
 
 test('Get localstorage', () => {
+  store.set('namef', false);
+  store.set('namenull', null);
   expect(store('name4')).toEqual('value4');
+  expect(store.get('namef')).toEqual(false);
   expect(store.get('name4')).toEqual('value4');
-  expect(store.get()).toEqual({ 'name4': 'value4', 'name5': 'value5' });
-  expect(store.get('name4', 'nameeee')).toEqual({ "name4": 'value4' });
+  expect(store.get()).toEqual({
+    'name4': 'value4',
+    'name5': 'value5',
+    'namef': false,
+    'namenull': null,
+    'nameundefined': undefined
+  });
+  expect(store.get('name4', 'nameeee', 'namef', 'namenull', 'nameundefined')).toEqual({
+    "name4": 'value4',
+    'namef': false,
+    'namenull': null,
+    'nameundefined': undefined
+  });
   expect(store.get('name4', 'name5')).toEqual({ "name4": 'value4', "name5": "value5" });
   expect(store.get('nameeee11', 'nameeee222')).toEqual({});
   expect(store.get('name4322323')).toBeUndefined();
+
+  store.remove('namef');
+  store.remove('namenull');
+  store.remove('nameundefined');
 });
 
 test('Get all localstorage', () => {


### PR DESCRIPTION
Before:

```js
store.set('a', 0)
store.set('b', false)
store.set('c', '')

store.get('a', 'b', 'c') // ==> {}
```

After:

```js
store.set('a', 0)
store.set('b', false)
store.set('c', '')

store.get('a', 'b', 'c') // ==> { a: 0, b: false, c: '' }
```